### PR TITLE
Add tests and README example for dependency graph script

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,22 @@ Examples:
 ```bash
 python3 scripts/dependency_graph.py . --dot deps.dot --json
 python3 scripts/dependency_graph.py . --tex lemma-silly --tex-out deps.tex
+python3 scripts/dependency_graph.py . --tex lemma-silly \
+  --lean-path ../mathlib4 --tex-out deps.tex
+python3 scripts/dependency_graph.py . \
+  --tex lemma-equality-genus-reduction-bigger-than \
+  --lean-path ../mathlib4-master --tex-out genus.tex
+python3 scripts/dependency_graph.py . \
+  --tex lemma-weil-additive \
+  --lean-path ../mathlib4-master --tex-out weil.tex
+python3 scripts/dependency_graph.py . \
+  --tex lemma-topological-invariance \
+  --lean-path ../mathlib4-master --tex-out invariance.tex
 ```
+
+The optional `--lean-path` argument points to a mathlib4 checkout. When
+provided, Lean snippets for Stacks tags referenced in mathlib are inserted
+after each environment in the generated TeX.
 
 Running the second command produces a TeX document with the theorem
 and its referenced environments.  For example the current output for

--- a/scripts/dependency_graph.py
+++ b/scripts/dependency_graph.py
@@ -13,6 +13,56 @@ ENVIRONMENTS = [
 PREFIXES = tuple(env + '-' for env in ENVIRONMENTS)
 
 
+def load_tag_map(path):
+    """Return mapping of Stacks tag numbers to labels."""
+    tag_file = os.path.join(path, 'tags', 'tags')
+    tag_map = {}
+    if not os.path.exists(tag_file):
+        return tag_map
+    with open(tag_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            parts = line.split(',')
+            if len(parts) == 2:
+                tag_map[parts[0]] = parts[1]
+    return tag_map
+
+
+def scan_mathlib(path, tag_map):
+    """Return mapping from Stacks labels to Lean code snippets."""
+    results = {}
+    tag_re = re.compile(r'https://stacks\.math\.columbia\.edu/tag/([0-9A-Za-z]+)')
+    env_re = re.compile(r'^(lemma|theorem|def|definition)\s+([\w\.]*)')
+    for root, _, files in os.walk(path):
+        for name in files:
+            if not name.endswith('.lean'):
+                continue
+            filename = os.path.join(root, name)
+            try:
+                with open(filename, 'r') as f:
+                    lines = f.readlines()
+            except Exception:
+                continue
+            for i, line in enumerate(lines):
+                m = tag_re.search(line)
+                if not m:
+                    continue
+                tag = m.group(1).upper()
+                label = tag_map.get(tag)
+                if not label:
+                    continue
+                # search upwards for lemma/def line
+                j = i
+                while j >= 0 and not env_re.search(lines[j]):
+                    j -= 1
+                start = max(j, 0)
+                snippet = ''.join(lines[start:i+3])
+                results[label] = snippet
+    return results
+
+
 def list_text_files(path):
     """Return stems of TeX files listed in the Makefile."""
     with open(os.path.join(path, 'Makefile'), 'r') as f:
@@ -114,8 +164,9 @@ def _extract_environment(path, label, results):
     return lines
 
 
-def generate_dependency_tex(label, results, edges, path, outfile):
-    """Write a TeX file with ``label`` and all its dependencies."""
+def generate_dependency_tex(label, results, edges, path, outfile, lean_snippets=None):
+    """Write a TeX file with ``label`` and all its dependencies.
+    If ``lean_snippets`` is provided, include corresponding Lean code."""
     adj = {}
     for src, dst in edges:
         adj.setdefault(src, []).append(dst)
@@ -133,12 +184,20 @@ def generate_dependency_tex(label, results, edges, path, outfile):
 
     visit(label)
 
+    lean_snippets = lean_snippets or {}
     with open(outfile, 'w') as f:
         f.write('\\documentclass{article}\n')
         f.write('\\begin{document}\n')
         for lbl in reversed(order):
             for line in _extract_environment(path, lbl, results):
                 f.write(line)
+            snippet = lean_snippets.get(lbl)
+            if snippet:
+                f.write('\\begin{verbatim}\n')
+                f.write(snippet)
+                if not snippet.endswith('\n'):
+                    f.write('\n')
+                f.write('\\end{verbatim}\n')
         f.write('\\end{document}\n')
 
 
@@ -150,6 +209,7 @@ def main():
     parser.add_argument('--json', action='store_true', help='Also output JSON data')
     parser.add_argument('--tex', metavar='LABEL', help='Generate TeX file for theorem LABEL and its deps')
     parser.add_argument('--tex-out', default='deps.tex', help='TeX output file (with --tex)')
+    parser.add_argument('--lean-path', help='Path to mathlib4 for Lean snippets')
     args = parser.parse_args()
 
     results, edges = build_graph(args.path)
@@ -157,8 +217,12 @@ def main():
     if args.json:
         with open('deps.json', 'w') as j:
             json.dump({'nodes': results, 'edges': edges}, j, indent=2)
+    lean_snippets = None
+    if args.lean_path:
+        tag_map = load_tag_map(args.path)
+        lean_snippets = scan_mathlib(args.lean_path, tag_map)
     if args.tex:
-        generate_dependency_tex(args.tex, results, edges, args.path, args.tex_out)
+        generate_dependency_tex(args.tex, results, edges, args.path, args.tex_out, lean_snippets)
 
 
 if __name__ == '__main__':

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,0 +1,47 @@
+import os
+import tempfile
+import unittest
+
+from scripts.dependency_graph import load_tag_map, scan_mathlib, generate_dependency_tex
+
+class DependencyGraphTests(unittest.TestCase):
+    def test_load_tag_map(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, 'tags'))
+            with open(os.path.join(d, 'tags', 'tags'), 'w') as f:
+                f.write('0001,label-foo\n0002,label-bar\n')
+            mp = load_tag_map(d)
+            self.assertEqual(mp['0001'], 'label-foo')
+            self.assertEqual(mp['0002'], 'label-bar')
+
+    def test_scan_mathlib(self):
+        with tempfile.TemporaryDirectory() as d:
+            tag_map = {'0001': 'label-foo'}
+            with open(os.path.join(d, 'test.lean'), 'w') as f:
+                f.write('lemma foo : True := by\n')
+                f.write('  -- https://stacks.math.columbia.edu/tag/0001\n')
+                f.write('  trivial\n')
+            res = scan_mathlib(d, tag_map)
+            self.assertIn('label-foo', res)
+            self.assertIn('lemma foo', res['label-foo'])
+
+    def test_generate_dependency_tex(self):
+        with tempfile.TemporaryDirectory() as d:
+            sample = os.path.join(d, 'sample.tex')
+            with open(sample, 'w') as f:
+                f.write('\\begin{lemma}\\label{lemma-a}A\\end{lemma}\n')
+                f.write('\\begin{lemma}\\label{lemma-b}\\ref{lemma-a}\\end{lemma}\n')
+            results = {
+                'lemma-a': {'type': 'lemma', 'file': 'sample'},
+                'lemma-b': {'type': 'lemma', 'file': 'sample'},
+            }
+            edges = [('lemma-b', 'lemma-a')]
+            snips = {'lemma-a': 'lemma foo : True := by trivial'}
+            out = os.path.join(d, 'out.tex')
+            generate_dependency_tex('lemma-b', results, edges, d, out, snips)
+            with open(out) as f:
+                data = f.read()
+            self.assertIn('lemma foo', data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test suite for `dependency_graph.py`
- document additional example using the mathlib cross-reference option
- expand README with further examples showcasing more lemmas

## Testing
- `python3 -m py_compile scripts/*.py`
- `python3 -m unittest tests/test_dependency_graph.py`


------
https://chatgpt.com/codex/tasks/task_e_684ad5da54888333939caf104145823f