### PR TITLE
Add full label support to dependency graph

### DIFF
--- a/README
+++ b/README
@@ -96,3 +96,24 @@ More on Morphisms of Spaces, Lemma
 \end{situation}
 \end{document}
 ```
+
+The script `scripts/compute_stats.py` can compute basic statistics for the dependency graph.
+It recognises Stacks references in mathlib via the standard URL as well as `@[stacks TAG]` attributes and "Stacks Tag TAG" docstrings.
+For example:
+```bash
+python3 scripts/compute_stats.py . --lean-path ../mathlib4 --json
+```
+prints a JSON summary of the number of environments, edges and Lean snippets.
+The field `num_nodes_with_lean_snippet` counts how many Stacks environments
+actually include a snippet of Lean code.
+
+Example output for a small test repository:
+```bash
+$ python3 scripts/compute_stats.py . --lean-path ../mathlib4 --json
+{
+  "num_nodes": 2,
+  "num_edges": 0,
+  "num_lean_snippets": 1,
+  "num_nodes_with_lean_snippet": 1
+}
+```

--- a/scripts/compute_stats.py
+++ b/scripts/compute_stats.py
@@ -1,0 +1,46 @@
+import argparse
+import json
+import os
+import sys
+
+if __package__ in (None, ""):
+    sys.path.insert(0, os.path.dirname(__file__))
+    import dependency_graph
+else:
+    from . import dependency_graph
+
+
+def compute_stats(path='.', lean_path=None):
+    """Return statistics about the Stacks Project dependency graph."""
+    results, edges = dependency_graph.build_graph(path)
+    stats = {
+        'num_nodes': len(results),
+        'num_edges': len(edges),
+    }
+    if lean_path:
+        tag_map = dependency_graph.load_tag_map(path)
+        lean_snippets = dependency_graph.scan_mathlib(lean_path, tag_map)
+        stats['num_lean_snippets'] = len(lean_snippets)
+        count = sum(1 for label in results if label in lean_snippets)
+        stats['num_nodes_with_lean_snippet'] = count
+    return stats
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Compute statistics for the Stacks Project.')
+    parser.add_argument('path', nargs='?', default='.', help='Path to Stacks Project root')
+    parser.add_argument('--lean-path', help='Path to mathlib4 checkout')
+    parser.add_argument('--json', action='store_true', help='Output JSON')
+    args = parser.parse_args()
+
+    stats = compute_stats(args.path, args.lean_path)
+
+    if args.json:
+        print(json.dumps(stats, indent=2))
+    else:
+        for k, v in stats.items():
+            print(f'{k}: {v}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_compute_stats.py
+++ b/tests/test_compute_stats.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from scripts.compute_stats import compute_stats
+
+class ComputeStatsTests(unittest.TestCase):
+    def test_compute_stats_with_lean(self):
+        with tempfile.TemporaryDirectory() as d:
+            # prepare minimal Stacks layout
+            os.makedirs(os.path.join(d, 'tags'))
+            with open(os.path.join(d, 'tags', 'tags'), 'w') as f:
+                f.write('ABCD,sample-label-foo\n')
+            with open(os.path.join(d, 'Makefile'), 'w') as f:
+                f.write('LIJST = sample\n')
+            with open(os.path.join(d, 'sample.tex'), 'w') as f:
+                f.write('\\begin{lemma}\n')
+                f.write('\\label{label-foo}\n')
+                f.write('A\\end{lemma}\n')
+            # minimal mathlib with stacks attribute
+            ml = os.path.join(d, 'ml')
+            os.makedirs(ml)
+            with open(os.path.join(ml, 'test.lean'), 'w') as f:
+                f.write('@[stacks ABCD]\nlemma foo : True := by trivial\n')
+            stats = compute_stats(d, ml)
+            self.assertEqual(stats['num_lean_snippets'], 1)
+            self.assertEqual(stats['num_nodes_with_lean_snippet'], 1)
+
+    def test_nodes_with_lean_snippet_count(self):
+        """Only nodes referenced in mathlib should be counted."""
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, 'tags'))
+            with open(os.path.join(d, 'tags', 'tags'), 'w') as f:
+                f.write('ABCD,foo-label-foo\nEFGH,bar-label-bar\n')
+            with open(os.path.join(d, 'Makefile'), 'w') as f:
+                f.write('LIJST = foo bar\n')
+            with open(os.path.join(d, 'foo.tex'), 'w') as f:
+                f.write('\\begin{lemma}\n\\label{label-foo}\nA\\end{lemma}\n')
+            with open(os.path.join(d, 'bar.tex'), 'w') as f:
+                f.write('\\begin{lemma}\n\\label{label-bar}\nB\\end{lemma}\n')
+            ml = os.path.join(d, 'ml')
+            os.makedirs(ml)
+            with open(os.path.join(ml, 'ref.lean'), 'w') as f:
+                f.write('@[stacks ABCD]\nlemma foo : True := by trivial\n')
+            stats = compute_stats(d, ml)
+            self.assertEqual(stats['num_nodes'], 2)
+            self.assertEqual(stats['num_lean_snippets'], 1)
+            self.assertEqual(stats['num_nodes_with_lean_snippet'], 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- include file prefix when parsing labels so mathlib snippets match
- track original label in results for environment extraction
- update tests for prefixed labels
- add README example showing `num_nodes_with_lean_snippet`
- add test covering node counting with Lean snippets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b1821112c83338b3c532afa936f9e