### PR TITLE
Improve interleave example and add test

### DIFF
--- a/README
+++ b/README
@@ -107,10 +107,17 @@ output looks like
 \documentclass{article}
 \begin{document}
 \noindent\begin{minipage}[t]{0.48\linewidth}
-\begin{lemma}\label{lemma-a}True\end{lemma}
+\begin{lemma}\label{lemma-a}
+For any $n \ge 0$ we have
+\[
+  \sum_{i=0}^n i = \frac{n(n+1)}{2}.
+\]
+\end{lemma}
 \end{minipage}\hfill\begin{minipage}[t]{0.48\linewidth}
 \begin{verbatim}
-lemma lemma_a : True := by trivial
+lemma lemma_a (n : Nat) :
+  (Finset.range (n + 1)).sum id = n * (n + 1) / 2 := by
+  simpa using Nat.sum_range_id n
 \end{verbatim}
 \end{minipage}
 \end{document}

--- a/tests/test_interleave_example.py
+++ b/tests/test_interleave_example.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from scripts.dependency_graph import generate_dependency_tex
+
+
+class InterleaveExampleTest(unittest.TestCase):
+    def test_interleave_multiple_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            sample = os.path.join(d, 'sample.tex')
+            with open(sample, 'w') as f:
+                f.write('\\begin{lemma}\\label{lemma-a}\n')
+                f.write('For $n \\ge 0$ we have $\\sum_{i=0}^n i = n(n+1)/2$.\\n')
+                f.write('\\end{lemma}\n')
+            results = {
+                'sample-lemma-a': {
+                    'type': 'lemma',
+                    'file': 'sample',
+                    'label': 'lemma-a',
+                }
+            }
+            edges = []
+            snippet = (
+                'lemma lemma_a (n : Nat) :\\n'
+                '  (Finset.range (n + 1)).sum id = n * (n + 1) / 2 := by\\n'
+                '  simpa using Nat.sum_range_id n'
+            )
+            snips = {'sample-lemma-a': snippet}
+            out = os.path.join(d, 'out.tex')
+            generate_dependency_tex('sample-lemma-a', results, edges, d, out, snips, interleave=True)
+            with open(out) as f:
+                data = f.read()
+            self.assertIn('Finset.range', data)
+            self.assertIn('minipage', data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- showcase a less trivial Lean snippet in the README interleave example
- add a unit test covering multi-line interleaving output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b47a2f5b8833394d16e36e139da38